### PR TITLE
Decompressor's finished() fix

### DIFF
--- a/src/org/anarres/lzo/hadoop/codec/LzoDecompressor.java
+++ b/src/org/anarres/lzo/hadoop/codec/LzoDecompressor.java
@@ -205,6 +205,8 @@ public class LzoDecompressor implements Decompressor {
     @Override
     public boolean finished() {
         // logState("Before finished");
+        if (outputBufferLen.value == 0 && outputBufferPos == 0)
+            return false;
         return outputBufferLen.value <= 0;
         // return false;
     }


### PR DESCRIPTION
Without this, hbase 0.90.4-cdh3u2 produces lots of warnings "org.apache.hadoop.hbase.io.hfile.Compression: Deompressor obtained from CodecPool is already finished()"
